### PR TITLE
Fix to #1: IE11 strict mode error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,28 +16,28 @@
 		}
 
 		try {
-			Object.defineProperty(Attr.prototype,			"parentElement", { configurable: false, enumerable: false, configurable: false, get: implementation });
+			Object.defineProperty(Attr.prototype, "parentElement", { configurable: false, enumerable: false, get: implementation });
 		} catch (e) {
 			// IE8
 			Attr.prototype.parentElement = implementation;
 		}
 
 		try {
-			Object.defineProperty(Text.prototype,			"parentElement", { configurable: false, enumerable: false, configurable: false, get: implementation });
+			Object.defineProperty(Text.prototype, "parentElement", { configurable: false, enumerable: false, get: implementation });
 		} catch (e) {
 			// IE8
 			Text.prototype.parentElement = implementation;
 		}
 
 		try {
-			Object.defineProperty(Element.prototype,	"parentElement", { configurable: false, enumerable: false, configurable: false, get: implementation });
+			Object.defineProperty(Element.prototype, "parentElement", { configurable: false, enumerable: false, get: implementation });
 		} catch (e) {
 			// IE8
 			Element.prototype.parentElement = implementation;
 		}
 
 		try {
-			Object.defineProperty(Document.prototype,	"parentElement", { configurable: false, enumerable: false, configurable: false, get: implementation });
+			Object.defineProperty(Document.prototype, "parentElement", { configurable: false, enumerable: false, get: implementation });
 		} catch (e) {
 			// IE8
 			Document.prototype.parentElement = implementation;


### PR DESCRIPTION
Fixes IE11 strict mode error “Multiple definitions of a property not allowed in strict mode” (issue #1)