### PR TITLE
Migrate from uglify-js to terser; bump rollup version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,17 @@
 {
   "name": "node.parentelement",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "A spec-compliant cross-browser polyfill for Node.parentElement",
   "main": "polyfill.min.js",
   "scripts": {
-		"build": "npm run build:dev && npm run build:min",
+    "build": "npm run build:dev && npm run build:min",
     "build:dev": "rollup -c rollup.config.js -o polyfill.js",
-		"build:min": "NODE_ENV=production rollup -c rollup.config.js -o polyfill.min.js"
+    "build:min": "NODE_ENV=production rollup -c rollup.config.js -o polyfill.min.js"
   },
   "author": "Frederik Wessberg",
   "license": "MIT",
   "devDependencies": {
-    "rollup": "^0.36.3",
-    "rollup-plugin-uglify": "^1.0.1",
-    "uglify-js": "github:mishoo/UglifyJS2#harmony"
+    "rollup": "^2.77.2",
+    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,32 +1,14 @@
-import {minify} from "uglify-js";
-import uglify from "rollup-plugin-uglify";
+import { terser } from "rollup-plugin-terser";
 
 const MINIFY = process.env.NODE_ENV === "production";
 
 export default {
-	entry: "src/index.js",
+	input: "src/index.js",
 	plugins: MINIFY ? [
-		uglify({
-			compress: {
-				warnings: false,
-				dead_code: true,
-				unsafe: false,
-				drop_console: true,
-				unused: true,
-				loops: true,
-				booleans: true,
-				conditionals: true,
-				sequences: true,
-				properties: true,
-				comparisons: true,
-				if_return: true,
-				join_vars: true,
-				cascade: true,
-				collapse_vars: true
-			},
-			screwIE8: false,
-			comments: false,
-			mangle: true
-		}, minify)
+		terser({
+			compress: true,
+			ie8: true,
+			mangle: true,
+		})
 	] : []
 }


### PR DESCRIPTION
Hi.
I found out that Your latest build is not updated to the latest version on npmjs.com (it still has annoying IE11 strict mode error). So I updated dependencies (because I could not build it with uglify-js) and changed to terser. Hope did not miss anything

Thanks for the polyfill! Need it in order to build hydratable Svelte page for IE 11 =)

P.S. Could You also update npmjs.com package please?)